### PR TITLE
Replace all "react-native" imports with "react" imports Find all impo…

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,14 +1,11 @@
 import { Navigation } from './common/navigation';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { Poppins_300Light ,Poppins_400Regular, Poppins_500Medium, Poppins_600SemiBold, Poppins_700Bold } from '@expo-google-fonts/poppins';
-import { useFonts } from 'expo-font';
+import { SafeAreaView } from 'react';
+import { Poppins_300Light ,Poppins_400Regular, Poppins_500Medium, Poppins_600SemiBold, Poppins_700Bold } from 'react';
 
 const App = () => {
+
+  //Fonts are loaded using CSS in the web app
   
-  const [fontsLoaded, fontError] = useFonts({ Poppins_300Light, Poppins_400Regular, Poppins_500Medium, Poppins_600SemiBold, Poppins_700Bold });
-
-  if (!fontsLoaded && !fontError) return null;
-
   return (
     <SafeAreaView style={{ flex: 1 }}>
       <Navigation />
@@ -16,4 +13,4 @@ const App = () => {
   );
 };
 
-export default App;
+export {App}; // This component will now be rendered from index.html, not App.js

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function(api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-  };
-};

--- a/common/loading.js
+++ b/common/loading.js
@@ -1,37 +1,30 @@
-import React from 'react';
-import { View, Animated, Easing, StyleSheet } from 'react-native';
-import LoadingIcon from '../assets/icons/loading.svg';
+import React, { useEffect, useRef } from 'react';
+import { useSpring, animated } from 'react-spring';
+import './loading.css';
 
 export const Loading = () => {
-  const spinValue = new Animated.Value(0);
+  const spinValue = useRef(0);
 
-  Animated.loop(
-    Animated.timing(spinValue, {
-      toValue: 1,
-      duration: 1000,
-      easing: Easing.linear,
-      useNativeDriver: true,
-    })
-  ).start();
-
-  const spin = spinValue.interpolate({
-    inputRange: [0, 1],
-    outputRange: ['0deg', '360deg'],
+  const { springValue } = useSpring({
+    from: { springValue: 0 },
+    to: async (next) => {
+      while (1) {
+        await next({ springValue: 1 });
+        await next({ springValue: 0 });
+      }
+    },
+    config: { duration: 1000 },
   });
 
+  useEffect(() => {
+    spinValue.current = springValue.to((val) => val * 360);
+  }, [springValue]);
+
   return (
-    <View style={styles.container}>
-      <Animated.View style={{ transform: [{ rotate: spin }] }}>
-        <LoadingIcon width={40} height={40} />
-      </Animated.View>
-    </View>
+    <div className="container">
+      <animated.div style={{ transform: spinValue.current.interpolate((val) => `rotate(${val}deg)`) }}>
+        <img src="/assets/icons/loading.svg" width="40px" height="40px" alt="Loading" />
+      </animated.div>
+    </div>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-});

--- a/common/navigation.js
+++ b/common/navigation.js
@@ -1,29 +1,25 @@
 import React from 'react';
-import { NavigationContainer } from '@react-navigation/native';
-import { createStackNavigator } from '@react-navigation/stack';
+import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import { Subscription } from '../pages/subscription';
 import { Home } from '../pages/home';
-import { bottomToTopTransition, rightToLeftTransition } from './transitions';
 import { SubscriptionPlan } from '../pages/subscription/plan';
 import { New } from '../pages/home/tabs/showdown/new';
 import { Trending } from '../pages/home/tabs/showdown/trending';
 import { ContestDetails } from '../pages/home/tabs/contests/contestDetails';
 import { JoinContest } from '../pages/home/tabs/contests/joinContest';
 
-const Stack = createStackNavigator();
-
 export const Navigation = () => {
   return (
-    <NavigationContainer>
-      <Stack.Navigator initialRouteName='home'>
-        <Stack.Screen name="home" component={Home} options={{ headerShown: false }} />
-        <Stack.Screen name="new" component={New} options={{ headerShown: false }} />
-        <Stack.Screen name="trending" component={Trending} options={{ headerShown: false }} />
-        <Stack.Screen name="subscription" component={Subscription} options={{ headerShown: false, cardStyleInterpolator: bottomToTopTransition }} />
-        <Stack.Screen name="subscription_plan" component={SubscriptionPlan} options={{ headerShown: false, cardStyleInterpolator: rightToLeftTransition }} />
-        <Stack.Screen name="contest_details" component={ContestDetails} options={{ headerShown: false}} initialParams={{ id: null, title: null }} />
-        <Stack.Screen name="join_contest" component={JoinContest} options={{ headerShown: false, cardStyleInterpolator: rightToLeftTransition }} initialParams={{ id: null, title: null }} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <Router>
+      <Switch>
+        <Route path="/home" component={Home} />
+        <Route path="/new" component={New} />
+        <Route path="/trending" component={Trending} />
+        <Route path="/subscription" component={Subscription} />
+        <Route path="/subscription_plan" component={SubscriptionPlan} />
+        <Route path="/contest_details" component={ContestDetails} initialParams={{ id: null, title: null }} />
+        <Route path="/join_contest" component={JoinContest} initialParams={{ id: null, title: null }} />
+      </Switch>
+    </Router>
   );
 };

--- a/common/transitions.js
+++ b/common/transitions.js
@@ -1,32 +1,33 @@
-export function bottomToTopTransition({ current, next, layouts }) {
-    const translateY = current.progress.interpolate({
-        inputRange: [0, 1],
-        outputRange: [layouts.screen.height, 0],
+import { useSpring, animated } from 'react-spring'
+
+export function bottomToTopTransition(props) {
+    const { y } = useSpring({
+        from: { y: props.height },
+        to: { y: 0 }
     });
 
-    const slideFromTop = { transform: [{ translateY }] };
-    const slideToTop = { transform: [{ translateY }] };
+    const slideFromTop = { transform: y.interpolate(y => `translate3d(0,${y}px,0)`) };
+    const slideToTop = { transform: y.interpolate(y => `translate3d(0,${y}px,0)`) };
 
     return {
-        cardStyle: next
+        cardStyle: props.next
             ? slideFromTop
             : slideToTop,
     };
 }
 
-export function rightToLeftTransition({ current, next, layouts }) {
-    const translateX = current.progress.interpolate({
-        inputRange: [0, 1],
-        outputRange: [layouts.screen.width, 0],
+export function rightToLeftTransition(props) {
+    const { x } = useSpring({
+        from: { x: props.width },
+        to: { x: 0 }
     });
 
-    const slideFromRight = { transform: [{ translateX }] };
-    const slideToLeft = { transform: [{ translateX }] };
+    const slideFromRight = { transform: x.interpolate(x => `translate3d(${x}px,0,0)`) };
+    const slideToLeft = { transform: x.interpolate(x => `translate3d(${x}px,0,0)`) };
 
     return {
-        cardStyle: next
+        cardStyle: props.next
             ? slideFromRight
             : slideToLeft,
     };
 }
-

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Styrate</title>
+        <link rel="stylesheet" type="text/css" href="style.css">
+    </head>
+    <body>
+        <div id="root"></div>
+        <script src="index.js"></script>
+    </body>
+</html>

--- a/public
+++ b/public
@@ -1,0 +1,1 @@
+// This is a new file so there's no existing code here.

--- a/styrate/index.js
+++ b/styrate/index.js
@@ -2,8 +2,8 @@
  * @format
  */
 
-import {AppRegistry} from 'react-native';
+import {AppRegistry} from 'react';
 import App from './App';
 import {name as appName} from './app.json';
 
-AppRegistry.registerComponent(appName, () => App);
+export default App;

--- a/utils/format.js
+++ b/utils/format.js
@@ -1,4 +1,4 @@
-import { Text } from "react-native";
+import { Text } from "react";
 import { COLORS, FONTS } from "../styles/styles";
 
 export class Format {


### PR DESCRIPTION
…rt statements using "react-native" and replace with "react". This will import the React libraries for web instead of React Native.  Replace "Animated" with a web animation library like "react-spring" or "react-transition-group" Use CSS transitions and animations powered by a web animation library instead of the React Native "Animated" API.  Replace "react-navigation/native" with "react-router-dom" Use the React router library for web apps to handle routing and navigation instead of the React Native navigation library.  Convert StyleSheet styles to CSS stylesheets Move the styles from StyleSheet objects to .css files and use CSS styles instead.  Replace React Native SVG file imports with HTML Replace SVG component imports with  elements containing HTML and CSS for loading indicators, icons, etc. Move images and assets to a "public" folder In a web app, static assets live in a public folder that is served by the server.  Remove Expo config files You don't need Expo config like "babel.config.js" for a web app - remove those files.  Export a component from "App.js" and render it from "index.html" The entry point for a web app is "index.html", not "App.js". Export a component from "App.js" and render it from the HTML.  Install "react-router-dom" Run npm install react-router-dom to get the web router library.